### PR TITLE
Add Lithuanian and English i18n

### DIFF
--- a/app/components/layout/Header.vue
+++ b/app/components/layout/Header.vue
@@ -4,11 +4,15 @@
       <ui-logo-text />
     </div>
     <div class="header__center">Navigation</div>
-    <div class="header__right">User Menu</div>
+    <div class="header__right">
+      <LanguageSwitcher />
+    </div>
   </header>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import LanguageSwitcher from "@/components/ui/LanguageSwitcher.vue";
+</script>
 
 <style scoped lang="scss">
 @use "@/assets/style/layout/_header.scss";

--- a/app/components/ui/LanguageSwitcher.vue
+++ b/app/components/ui/LanguageSwitcher.vue
@@ -1,0 +1,6 @@
+<template>
+  <select v-model="$i18n.locale">
+    <option value="en">English</option>
+    <option value="lt">Lietuvių</option>
+  </select>
+</template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <h1>Welcome to the Home Page</h1>
-    <p>This is the main content of the home page.</p>
+    <h1>{{ $t('home.title') }}</h1>
+    <p>{{ $t('home.content') }}</p>
   </div>
 </template>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "home": {
+    "title": "Welcome to the Home Page",
+    "content": "This is the main content of the home page."
+  }
+}

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -1,0 +1,6 @@
+{
+  "home": {
+    "title": "Sveiki atvykę į pagrindinį puslapį",
+    "content": "Tai yra pagrindinio puslapio turinys."
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   compatibilityDate: "2025-07-15",
   devtools: { enabled: true },
-  modules: ["@nuxt/eslint"],
+  modules: ["@nuxt/eslint", "@nuxtjs/i18n"],
   runtimeConfig: {
     public: {
       supabaseUrl: process.env.SUPABASE_URL,
@@ -13,4 +13,16 @@ export default defineNuxtConfig({
     "@/assets/style/base/_typography.scss",
     "@/assets/style/base/_normalize.scss",
   ],
+  i18n: {
+    locales: [
+      { code: "en", name: "English", file: "en.json" },
+      { code: "lt", name: "Lithuanian", file: "lt.json" },
+    ],
+    defaultLocale: "en",
+    lazy: true,
+    langDir: "locales/",
+    vueI18n: {
+      fallbackLocale: "en",
+    },
+  },
 });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/pro-regular-svg-icons": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.0.8",
     "@nuxt/eslint": "^1.6.0",
+    "@nuxtjs/i18n": "^8.0.0",
     "@supabase/supabase-js": "^2.52.0",
     "eslint": "^9.31.0",
     "nuxt": "^4.0.0",


### PR DESCRIPTION
## Summary
- install `@nuxtjs/i18n` dependency
- configure i18n module in `nuxt.config.ts`
- add example translations for English and Lithuanian
- show translated strings on the home page
- add a simple language switcher in the header

## Testing
- `npm install` *(fails: 403 Forbidden from npm.fontawesome.com)*

------
https://chatgpt.com/codex/tasks/task_e_687bc5c6e1d48326ae1dcdba0a2ba925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a language switcher in the header, allowing users to select between English and Lithuanian.
  * Added support for internationalization (i18n) across the application.
  * Home page content now dynamically displays in the selected language.

* **Chores**
  * Added English and Lithuanian translation files.
  * Updated configuration and dependencies to support multilingual functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->